### PR TITLE
Unset layout for ExperimentResult to avoid any view path conflicts

### DIFF
--- a/src/EPiServer.Marketing.Testing.Web/Views/ExperimentResult/Index.cshtml
+++ b/src/EPiServer.Marketing.Testing.Web/Views/ExperimentResult/Index.cshtml
@@ -1,6 +1,8 @@
 ﻿@using EPiServer.Marketing.Testing.Dal.DataAccess.FullSttack.Core.Impl.Models
 @model OptiExperimentResults
-
+@{
+    Layout = null;
+}
 
 @{
 if (Model.Reach != null)


### PR DESCRIPTION
This PR is made to fix the issue: https://github.com/episerver/content-feature-experimentation/issues/1

Explanation: There is a _ViewStart file under \EPiServer.Marketing.KPI.Commerce\EPiServer.Marketing.KPI.Commerce.Views\Views\. In the other hand, the QuickSilver sample  site already has another _viewstart.cshtml, so it causes wrong layout is being used, hence this bug happens.
Since ExperimentResult is an embedded iframe, I think we should unset its Layout to avoid any view path conflicts with other web apps.