### PR TITLE
Update Nuget license file template

### DIFF
--- a/build/licenses/LICENSE.txt.template
+++ b/build/licenses/LICENSE.txt.template
@@ -1,11 +1,17 @@
-EPISERVER SOFTWARE LICENSE
+OPTIMIZELY NUGET PACKAGES
+RIGHTS OF USE
 
-SOFTWARE LICENSE
-Refer to the Episerver End User License Agreement:
-https://www.episerver.com/eula.
 
-IMPLEMENTED SOFTWARE
-Implemented Software, as defined by the Episerver End User License Agreement
-(https://www.episerver.com/eula), used in this Nuget package is listed below
-together with the corresponding license.
+For Customers with Software Services Use Terms under an Optimizely Software
+Subscription Agreement –
+https://www.optimizely.com/legal/software-services-use-terms
+
+For Customers with legacy end user license agreement or legacy end user
+services agreement - 
+https://www.optimizely.com/legal/end-user-licence-agreement, or 
+https://www.optimizely.com/legal/end-user-services-agreement 
+
+
+Additional license terms and /or notices with respect to this Nuget Package,
+if any, are set out below.
 

--- a/build/licenses/NO-THIRD-PARTY-LICENSES.txt
+++ b/build/licenses/NO-THIRD-PARTY-LICENSES.txt
@@ -1,1 +1,0 @@
-No additional Implemented Software is included in this package.

--- a/build/nuspec.props
+++ b/build/nuspec.props
@@ -6,15 +6,14 @@
 		<NuspecProperties>Configuration=$(Configuration);Version=$(PackageVersion)</NuspecProperties>
 		<PackageOutputPath>$(SolutionDir)artifacts\packages\</PackageOutputPath>
 		<TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);GenerateLicenseFiles</TargetsForTfmSpecificContentInPackage>
-		<LicenseFiles>$(SolutionDir)build\licenses\NO-THIRD-PARTY-LICENSES.txt</LicenseFiles>
 		<LicenseTemplate>$(SolutionDir)build\licenses\LICENSE.txt.template</LicenseTemplate>
 	</PropertyGroup>
 
 	<Target Name="GenerateLicenseFiles"  >
 		<ItemGroup>
-			<LicenseFiles Include="$(LicenseTemplate)" Condition="'$(LicenseTemplate)' != ''" />
-			<LicenseFiles Include="$(LicenseFiles)" Condition="'$(LicenseFiles)' != ''"/>
-			<LicenseContents Include="$([System.IO.File]::ReadAllText(%(LicenseFiles.Identity)))" Condition="'$(LicenseFiles)' != ''"/>
+			<LicenseItems Include="$(LicenseTemplate)" Condition="'$(LicenseTemplate)' != ''" />
+			<LicenseItems Include="$(LicenseFiles)" Condition="'$(LicenseFiles)' != ''"/>
+			<LicenseContents Include="$([System.IO.File]::ReadAllText(%(LicenseItems.Identity)))" Condition="'@(LicenseItems)' != ''"/>
 		</ItemGroup>
 		<WriteLinesToFile File="license.txt" Lines="@(LicenseContents->'%(Identity)%0D%0A')" Overwrite="true" />
 	</Target>


### PR DESCRIPTION
Update license texts in Nuget packages as required by legal:
- Update license header with new template.
- Remove message used when there are no 3rd party licenses, so that packages without 3rd party licenses include just the header.